### PR TITLE
Revert "build(deps): bump org.junit.jupiter:junit-jupiter-engine from 5.11.4 to 5.12.0 in /packages/dsl-java"

### DIFF
--- a/packages/dsl-java/build.gradle
+++ b/packages/dsl-java/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     // Execution of tests
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.12.0'
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.12.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.11.4'
 
     // client implementation under test, in test.httpclient.implementation
     testImplementation 'org.apache.httpcomponents:fluent-hc:4.5.14'


### PR DESCRIPTION
Reverts case-contract-testing/contract-case#893 , this appears to be a broken dependency