### PR TITLE
chore: Fix non-string state variable serialization

### DIFF
--- a/packages/case-connector/src/connectors/case-boundary/internals/mappers/triggers.ts
+++ b/packages/case-connector/src/connectors/case-boundary/internals/mappers/triggers.ts
@@ -14,7 +14,12 @@ const mapSetupInfo = ({
   functions,
   mock,
 }: BaseSetupInfo): BoundarySetupInfo => ({
-  stateVariables,
+  stateVariables: Object.fromEntries(
+    Object.entries(stateVariables).map(([key, value]) => [
+      key,
+      typeof value === 'string' ? value : JSON.stringify(value),
+    ]),
+  ),
   mock,
   functions: Object.entries(functions)
     .map(


### PR DESCRIPTION
### Problem I encountered

When using the Java DSL, I was experimenting with state variables.
I used [InStateWithVariables](https://github.com/case-contract-testing/contract-case/blob/main/packages/dsl-java/src/main/java/io/contract_testing/contractcase/dsl/states/InStateWithVariables.java) like so:
```java
var placeholderId = "some_id";
var placeholderCost = 123;
new InStateWithVariables(
  "a product exists",
  Map.of("id", placeholderId, "cost", placeholderCost))
```
In my `IndividualSuccessTestConfigBuilder.withTestResponse`, I found found the following problem:
```java
.withTestResponse(
  (response, setupInfo) -> {
    // This check works
    assertThat(response.id).isEqualTo(setupInfo.getStateVariable("id"));
    // This check doesn't. State variable value is "", expected "123", fails parseInt
    assertThat(response.cost).isEqualTo(Integer.parseInt(setupInfo.getStateVariable("cost")));
  }
);
```

### Cause

In the gRPC layer, you assign set the value of a `StringValue` to the mapper state variable value. The value inside Contract Case is an integer. `StringValue` can't take integers, and sets its value to `""` if you try.

### Fix

Map the values to strings.

### Note

The `mock` value right next to this also remains unmapped. This didn't affect me and I don't know anything about the `mock` field, so I didn't touch it, but it's possible that is a similar bug. If so, you might wanna fix that too.