### PR TITLE
feat: Add advice override for 'MISSING_TRIGGER_FUNCTION'

### DIFF
--- a/packages/case-core/src/core/executeExample/triggers.ts
+++ b/packages/case-core/src/core/executeExample/triggers.ts
@@ -16,6 +16,11 @@ import type { InvokingScaffold, Trigger } from './types';
 import { Assertable } from '../../entities/types';
 import { CaseFailedAssertionError } from '../../entities';
 
+const advice = (context: MatchContext) =>
+  context['_case:currentRun:context:adviceOverrides']?.[
+    'MISSING_TRIGGER_FUNCTION'
+  ] ?? `Please check that you have configured the appropriate trigger function`;
+
 const invokeTrigger = <T extends AnyMockDescriptorType, R>(
   trigger: Trigger<T, R>,
   testResponse: (data: R, config: Assertable<T>['config']) => unknown,
@@ -213,7 +218,7 @@ export const findAndCallTrigger = <T extends AnyMockDescriptorType, R>(
         `No trigger for request '${names.requestName}' provided`,
       );
       throw new CaseConfigurationError(
-        `No trigger provided for request:\n     ${names.requestName}`,
+        `No trigger provided for request:\n     ${names.requestName}\n\n${advice(context)}`,
         context,
         'MISSING_TRIGGER_FUNCTION',
       );
@@ -251,22 +256,20 @@ export const findAndCallTrigger = <T extends AnyMockDescriptorType, R>(
             names.responseName
           }\n However, tests for that response name do exist in the following configurations:\n${endsWith
             .map((s) => `        ${s.split('::')[0]}`)
-            .join(
-              '\n',
-            )}\n\nPlease check that you have configured the appropriate trigger function\n`,
+            .join('\n')}\n\n${advice(context)}\n`,
           context,
           'MISSING_TRIGGER_FUNCTION',
         );
       }
 
       throw new CaseConfigurationError(
-        `Missing a trigger for:\n       ${names.requestName}\n  this should be paired with a test for:\n       ${names.responseName}`,
+        `Missing a trigger for:\n       ${names.requestName}\n  this should be paired with a test for:\n       ${names.responseName}\n\n${advice(context)}`,
         context,
         'MISSING_TRIGGER_FUNCTION',
       );
     }
     throw new CaseConfigurationError(
-      `No trigger or trigger map provided for:\n     ${names.requestName}\n  You must set a trigger or a trigger map`,
+      `No trigger or trigger map provided for:\n     ${names.requestName}\n  You must set a trigger or a trigger map\n\n${advice(context)}`,
       context,
       'MISSING_TRIGGER_FUNCTION',
     );


### PR DESCRIPTION
### Context

I support an internal wrapper library around Contract Case.
I want to provide custom error messages on particular failures so that I can give internal users guidance on how to fix their problem in the context of our wrapper library.
Advice overrides are already supported for `MISSING_REGISTERED_FUNCTION` ([source](https://github.com/case-contract-testing/contract-case/blob/c22ddacc30c0114b84227c3f17422201658fbf2d/packages/case-core/src/core/BaseCaseContract.ts#L152-L154)), but not for `MISSING_TRIGGER_FUNCTION`.

### Done in this PR

Added support for custom advice overrides for the error code `MISSING_TRIGGER_FUNCTION`.

Behaviour of the change was manually verified by testing it in my project that uses Contract Case.