### PR TITLE
ci: Add keep-node-current workflow

### DIFF
--- a/.github/workflows/keep-node-current.yml
+++ b/.github/workflows/keep-node-current.yml
@@ -1,0 +1,33 @@
+name: Keep Node current
+
+on:
+  schedule:
+    # Every Monday at 06:15 UTC
+    - cron: '15 6 * * 1'
+  workflow_dispatch:
+
+# Least privilege at the top level; the job that needs write asks for it below.
+permissions: read-all
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Keep Node current
+        uses: TimothyJones/github-action-keep-node-current@f8b1f7c33795cd02a25dd67db5564afcfc115eb8 # v1.0.1
+        with:
+          # The default GITHUB_TOKEN cannot edit files under .github/workflows/,
+          # which this action needs to bump the CI node-version matrix. Use a PAT
+          # with `workflow` scope stored as the SYNC_PAT repository secret.
+          token: ${{ secrets.SYNC_PAT }}


### PR DESCRIPTION
Sets up [keep-node-current](https://github.com/marketplace/actions/keep-node-current) to keep Node versions current across the repo.

## What it does
A scheduled workflow (Mondays 06:15 UTC + `workflow_dispatch`) that runs the action to bump Node versions as majors move in/out of support, opening a PR with any changes. It updates:
- `.nvmrc`
- `package.json` `engines.node`
- the CI `node-version` matrix (e.g. `build-and-test.yml`)

Follows repo conventions: SHA-pinned actions with version comments, hardened runner, least-privilege top-level `read-all` with write scoped to the job.

## Required setup before this works ⚠️
1. **Create a `SYNC_PAT` repository secret.** The default `GITHUB_TOKEN` cannot edit files under `.github/workflows/`, which is needed to bump the CI matrix. Use a PAT with `workflow` scope (classic: `repo` + `workflow`; fine-grained: Contents + Pull requests + Workflows, read & write).
2. **Enable PR creation:** Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests".

Pinned to `v1.0.1` (`f8b1f7c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)