### PR TITLE
ci: Fix keep-node-current push (duplicate Authorization header)

### DIFF
--- a/.github/workflows/keep-node-current.yml
+++ b/.github/workflows/keep-node-current.yml
@@ -23,6 +23,11 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Don't leave checkout's Authorization extraheader in the git config;
+          # the action pushes with its own token, and both being present makes
+          # git send a duplicate Authorization header (remote 400 on push).
+          persist-credentials: false
 
       - name: Keep Node current
         uses: TimothyJones/github-action-keep-node-current@6702717590b2ea4b147dd9007e9dda0d05d2ffc4 # v1.0.2


### PR DESCRIPTION
The manually-dispatched [run](https://github.com/case-contract-testing/contract-case/actions/runs/29638395096) confirmed the action's logic works (it planned: drop Node 20, add Node 26), but the **git push failed**:

```
##[error]git push --force origin chore/node-version-sync failed (exit 128):
         remote: Duplicate header: "Authorization"
fatal: ... The requested URL returned error: 400
```

`actions/checkout` persists a credential (`http.extraheader` Authorization) in the git config by default. When the action then pushes with its own token, git sends **two** Authorization headers and GitHub returns 400.

Fix: set `persist-credentials: false` on the checkout step so only the action's token is used — the same pattern already used in `scorecard.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)