### PR TITLE
feat!: Drop support for node version 20, add support for node version 26

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Harden Runner

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Harden Runner

--- a/.github/workflows/builld-and-test-pr.yml
+++ b/.github/workflows/builld-and-test-pr.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Harden Runner

--- a/.github/workflows/builld-and-test-pr.yml
+++ b/.github/workflows/builld-and-test-pr.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Harden Runner


### PR DESCRIPTION
Automated sync of Node.js versions against the official release schedule.

### Added
- Node 26

### Dropped
- Node 20

Source: https://raw.githubusercontent.com/nodejs/Release/refs/heads/main/schedule.json