### PR TITLE
build(deps): bump github/codeql-action/init and analyze from 4.37.0 to 4.37.1

### DIFF
--- a/.github/workflows/codeql-java.yml
+++ b/.github/workflows/codeql-java.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3.29.5
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v3.29.5
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -66,6 +66,6 @@ jobs:
           NODE_VERSION: 22
           FORCE_COLOR: true
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3.29.5
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v3.29.5
         with:
           category: '/language:${{matrix.language}}'

--- a/.github/workflows/codeql-ts.yml
+++ b/.github/workflows/codeql-ts.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3.29.5
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v3.29.5
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -61,6 +61,6 @@ jobs:
         with:
           node-version: 22.x
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3.29.5
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v3.29.5
         with:
           category: '/language:${{matrix.language}}'


### PR DESCRIPTION
## Summary
- Combines #1360 and #1362, two Dependabot PRs that both bump `github/codeql-action` from 4.37.0 to 4.37.1, touching the same two workflow files
- Bumps `github/codeql-action/init` from 4.37.0 to 4.37.1 in `.github/workflows/codeql-java.yml` and `.github/workflows/codeql-ts.yml` (originally PR #1360)
- Bumps `github/codeql-action/analyze` from 4.37.0 to 4.37.1 in the same two files (originally PR #1362)

## Test plan
- [ ] CI workflows (`codeql-java.yml`, `codeql-ts.yml`) run successfully with the updated action versions

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsSABY2hcXnkgPG5LDyCva)_