### PR TITLE
fix: Function contract error messages are now respected at match time

### DIFF
--- a/packages/case-core-plugin-function/src/matchers/FunctionResultMatcher.spec.ts
+++ b/packages/case-core-plugin-function/src/matchers/FunctionResultMatcher.spec.ts
@@ -319,6 +319,58 @@ describe('FunctionResultMatcherExecutor', () => {
           );
         });
       });
+
+      describe('when the matcher includes a message', () => {
+        const errorMatcherWithMessage: CoreFunctionErrorResultMatcher = {
+          ...errorMatcher,
+          message: 'expected-message' as unknown as AnyCaseMatcherOrData,
+        };
+
+        it('checks error result with message', async () => {
+          mockMatchContext = createMockMatchContext({
+            descendAndCheckResult: [],
+            descendAndStripResult: 'stripped',
+            descendAndDescribeResult: describeMessage('"default"'),
+          });
+
+          const actual = {
+            errorClassName: 'SomeError',
+            message: 'expected-message',
+          };
+
+          const result = await FunctionResultMatcherExecutor.check(
+            errorMatcherWithMessage,
+            mockMatchContext,
+            actual,
+          );
+
+          expect(result).toEqual([]);
+        });
+
+        it('returns an error when the message does not match', async () => {
+          const messageMismatchError = { message: 'message mismatch' } as any;
+          // errorClassName matches (first call), message does not (second call)
+          const descendAndCheckResultsInOrder = [[], [messageMismatchError]];
+          mockMatchContext = {
+            ...mockMatchContext,
+            descendAndCheck: () =>
+              Promise.resolve(descendAndCheckResultsInOrder.shift() ?? []),
+          };
+
+          const actual = {
+            errorClassName: 'SomeError',
+            message: 'a different message',
+          };
+
+          const result = await FunctionResultMatcherExecutor.check(
+            errorMatcherWithMessage,
+            mockMatchContext,
+            actual,
+          );
+
+          expect(result).toEqual([messageMismatchError]);
+        });
+      });
     });
   });
 

--- a/packages/case-core-plugin-function/src/matchers/FunctionResultMatcher.ts
+++ b/packages/case-core-plugin-function/src/matchers/FunctionResultMatcher.ts
@@ -15,6 +15,7 @@ import {
   concatenateDescribe,
   describeMessage,
   renderToString,
+  combineResults,
 } from '@contract-case/case-plugin-base';
 import { AnyData } from '@contract-case/case-plugin-dsl-types';
 import { isObject } from '../entities';
@@ -144,7 +145,7 @@ const check = async (
   matchContext: MatchContext,
   actual: unknown,
 ): Promise<MatchResult> =>
-  Promise.resolve().then(() => {
+  Promise.resolve().then(async () => {
     if (!isObject(actual)) {
       throw new CaseCoreError(
         `FunctionResultMatcher check() received a non-object response from a function. This indicates a bug in the function wrapper lib. What was returned was: ${actual}`,
@@ -192,11 +193,20 @@ const check = async (
     } else {
       // We're expecting failure
       if ('errorClassName' in actual) {
-        return matchContext.descendAndCheck(
+        const errorClassNameResult = await matchContext.descendAndCheck(
           matcher.errorClassName,
           addLocation(`thrownErrorKind`, matchContext),
           actual['errorClassName'],
         );
+        if ('message' in matcher && matcher.message != null) {
+          const messageResult = await matchContext.descendAndCheck(
+            matcher.message,
+            addLocation(`message`, matchContext),
+            'message' in actual ? actual['message'] : undefined,
+          );
+          return combineResults(errorClassNameResult, messageResult);
+        }
+        return errorClassNameResult;
       }
       // But it was a success
       return [
@@ -250,8 +260,8 @@ const validate = (
       .then(async () => {
         if ('message' in matcher && matcher.message != null) {
           await matchContext.descendAndValidate(
-            matcher.errorClassName,
-            addLocation('errorClassName', matchContext),
+            matcher.message,
+            addLocation('message', matchContext),
           );
         }
       });


### PR DESCRIPTION
Fixes the issue described in https://github.com/case-contract-testing/contract-case/issues/1397.
* properly makes `validate` check `message` when `message` is present, instead of checking `errorClassName` a second time
* makes `check` check `message` when `message` is present, instead of ignoring it
* adds tests