### PR TITLE
docs: Fix documentation links and add missing JSDoc comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "nx": "^22.5.2"
       },
       "devDependencies": {
-        "@contract-case/eslint-config-case-maintainer": "0.31.1",
+        "@contract-case/eslint-config-case-maintainer": "0.31.2",
         "example-extractor": "^0.0.4",
         "jsii-docgen": "^10.11.4",
         "lerna": "^10.0.1",

--- a/packages/case-definition-dsl/api-extractor.json
+++ b/packages/case-definition-dsl/api-extractor.json
@@ -49,5 +49,23 @@
      * DEFAULT VALUE: ""
      */
     "projectFolderUrl": "https://github.com/case-contract-testing/contract-case/tree/main/packages/case-definition-dsl"
+  },
+
+  "messages": {
+    "extractorMessageReporting": {
+      /**
+       * This package exposes its API through `import * as` namespaces
+       * (interactions, matchers, states). API Extractor's declaration
+       * reference resolver can't follow namespace re-exports yet
+       * (https://github.com/microsoft/rushstack/issues/1308), so it reports
+       * ae-unresolved-link for links that are actually correct.
+       * api-documenter resolves these same links against the doc model and
+       * still warns on any genuinely broken reference, so we suppress the
+       * false positives here.
+       */
+      "ae-unresolved-link": {
+        "logLevel": "none"
+      }
+    }
   }
 }

--- a/packages/case-definition-dsl/api-extractor/case-definition-dsl.api.json
+++ b/packages/case-definition-dsl/api-extractor/case-definition-dsl.api.json
@@ -926,7 +926,7 @@
                     {
                       "kind": "Constructor",
                       "canonicalReference": "@contract-case/case-definition-dsl!interactions.functions.WillCallFunction:constructor(1)",
-                      "docComment": "/**\n * Defines an interaction that executes a registered function with specific arguments, expecting that interaction to return successfully\n *\n * @param example - a {@link mocks.functions.FunctionExecutionExample}\n */\n",
+                      "docComment": "/**\n * Defines an interaction that executes a registered function with specific arguments, expecting that interaction to return successfully\n *\n * @param example - a {@link interactions.functions.FunctionExecutionExample}\n */\n",
                       "excerptTokens": [
                         {
                           "kind": "Content",
@@ -1083,7 +1083,7 @@
                     {
                       "kind": "Constructor",
                       "canonicalReference": "@contract-case/case-definition-dsl!interactions.functions.WillCallThrowingFunction:constructor(1)",
-                      "docComment": "/**\n * Defines an example that executes a registered function with specific arguments\n *\n * @param example - a {@link mocks.functions.FunctionExecutionExample}\n */\n",
+                      "docComment": "/**\n * Defines an example that executes a registered function with specific arguments\n *\n * @param example - a {@link interactions.functions.FunctionExecutionExample}\n */\n",
                       "excerptTokens": [
                         {
                           "kind": "Content",
@@ -1240,7 +1240,7 @@
                     {
                       "kind": "Constructor",
                       "canonicalReference": "@contract-case/case-definition-dsl!interactions.functions.WillReceiveFunctionCall:constructor(1)",
-                      "docComment": "/**\n * Defines an example that expects a function to be called with specific arguments\n *\n * @param example - a {@link mocks.functions.FunctionExecutionExample}\n */\n",
+                      "docComment": "/**\n * Defines an example that expects a function to be called with specific arguments\n *\n * @param example - a {@link interactions.functions.FunctionExecutionExample}\n */\n",
                       "excerptTokens": [
                         {
                           "kind": "Content",
@@ -1397,7 +1397,7 @@
                     {
                       "kind": "Constructor",
                       "canonicalReference": "@contract-case/case-definition-dsl!interactions.functions.WillReceiveFunctionCallAndThrow:constructor(1)",
-                      "docComment": "/**\n * Defines an example that expects a function to be called with specific arguments\n *\n * @param example - a {@link mocks.functions.FunctionExecutionExample}\n */\n",
+                      "docComment": "/**\n * Defines an example that expects a function to be called with specific arguments\n *\n * @param example - a {@link interactions.functions.FunctionExecutionExample}\n */\n",
                       "excerptTokens": [
                         {
                           "kind": "Content",
@@ -1640,7 +1640,7 @@
                     {
                       "kind": "Constructor",
                       "canonicalReference": "@contract-case/case-definition-dsl!interactions.http.WillReceiveHttpRequest:constructor(1)",
-                      "docComment": "/**\n * Defines an example that expects to receive an HTTP request. Use this to define a contract at an HTTP client.\n *\n * @param httpExample - an {@link mocks.http.HttpExample}\n */\n",
+                      "docComment": "/**\n * Defines an example that expects to receive an HTTP request. Use this to define a contract at an HTTP client.\n *\n * @param httpExample - an {@link interactions.http.HttpExample}\n */\n",
                       "excerptTokens": [
                         {
                           "kind": "Content",
@@ -2529,7 +2529,7 @@
                     {
                       "kind": "Constructor",
                       "canonicalReference": "@contract-case/case-definition-dsl!matchers.base.AnyMatcher:constructor(1)",
-                      "docComment": "/**\n * The base class for all Test Equivalence Matchers. Extend this if you don't have an example in your Matcher. Otherwise, use {@link matchers.internals.AnyMatcherWithExample} Matcher strings beginning with `_case:` are reserved for the default ContractCase matchers.\n *\n * Only use a types prefixed with `_case:` if you wish to create a special case for a matching behaviour that is already provided by a core ContractCase matcher.\n *\n * @param matcherType - The type string for this matcher (see {@link https://case.contract-testing.io/docs/reference/plugin-framework | Extending ContractCase} for a description of these strings).\n */\n",
+                      "docComment": "/**\n * The base class for all Test Equivalence Matchers. Extend this if you don't have an example in your Matcher. Otherwise, use {@link matchers.base.AnyMatcherWithExample} Matcher strings beginning with `_case:` are reserved for the default ContractCase matchers.\n *\n * Only use a types prefixed with `_case:` if you wish to create a special case for a matching behaviour that is already provided by a core ContractCase matcher.\n *\n * @param matcherType - The type string for this matcher (see {@link https://case.contract-testing.io/docs/reference/plugin-framework | Extending ContractCase} for a description of these strings).\n */\n",
                       "excerptTokens": [
                         {
                           "kind": "Content",

--- a/packages/case-definition-dsl/docs-json/typescript.json
+++ b/packages/case-definition-dsl/docs-json/typescript.json
@@ -3,7 +3,7 @@
   "language": "typescript",
   "metadata": {
     "packageName": "@contract-case/case-definition-dsl",
-    "packageVersion": "0.31.1"
+    "packageVersion": "0.31.2"
   },
   "apiReference": {
     "constructs": [],
@@ -176,7 +176,7 @@
                     "displayName": "ContractCaseCoreSetup",
                     "fqn": "@contract-case/case-definition-dsl.interactions.base.ContractCaseCoreSetup",
                     "packageName": "@contract-case/case-definition-dsl",
-                    "packageVersion": "0.31.1",
+                    "packageVersion": "0.31.2",
                     "submodule": "interactions"
                   }
                 ]
@@ -699,7 +699,7 @@
                     "displayName": "ArrayLengthOptions",
                     "fqn": "@contract-case/case-definition-dsl.matchers.arrays.ArrayLengthOptions",
                     "packageName": "@contract-case/case-definition-dsl",
-                    "packageVersion": "0.31.1",
+                    "packageVersion": "0.31.2",
                     "submodule": "matchers"
                   }
                 ]
@@ -1196,7 +1196,7 @@
                     "displayName": "HttpRequestExample",
                     "fqn": "@contract-case/case-definition-dsl.matchers.http.HttpRequestExample",
                     "packageName": "@contract-case/case-definition-dsl",
-                    "packageVersion": "0.31.1",
+                    "packageVersion": "0.31.2",
                     "submodule": "matchers"
                   }
                 ]
@@ -1315,7 +1315,7 @@
                     "displayName": "HttpResponseExample",
                     "fqn": "@contract-case/case-definition-dsl.matchers.http.HttpResponseExample",
                     "packageName": "@contract-case/case-definition-dsl",
-                    "packageVersion": "0.31.1",
+                    "packageVersion": "0.31.2",
                     "submodule": "matchers"
                   }
                 ]
@@ -2225,14 +2225,14 @@
                     "displayName": "FunctionExecutionExample",
                     "fqn": "@contract-case/case-definition-dsl.interactions.functions.FunctionExecutionExample",
                     "packageName": "@contract-case/case-definition-dsl",
-                    "packageVersion": "0.31.1",
+                    "packageVersion": "0.31.2",
                     "submodule": "interactions"
                   }
                 ]
               },
               "variadic": false,
               "docs": {
-                "summary": "- a {@link mocks.functions.FunctionExecutionExample }."
+                "summary": "- a {@link interactions.functions.FunctionExecutionExample }."
               }
             }
           ],
@@ -2322,14 +2322,14 @@
                     "displayName": "ThrowingFunctionExecutionExample",
                     "fqn": "@contract-case/case-definition-dsl.interactions.functions.ThrowingFunctionExecutionExample",
                     "packageName": "@contract-case/case-definition-dsl",
-                    "packageVersion": "0.31.1",
+                    "packageVersion": "0.31.2",
                     "submodule": "interactions"
                   }
                 ]
               },
               "variadic": false,
               "docs": {
-                "summary": "- a {@link mocks.functions.FunctionExecutionExample }."
+                "summary": "- a {@link interactions.functions.FunctionExecutionExample }."
               }
             }
           ],
@@ -2419,14 +2419,14 @@
                     "displayName": "FunctionExecutionExample",
                     "fqn": "@contract-case/case-definition-dsl.interactions.functions.FunctionExecutionExample",
                     "packageName": "@contract-case/case-definition-dsl",
-                    "packageVersion": "0.31.1",
+                    "packageVersion": "0.31.2",
                     "submodule": "interactions"
                   }
                 ]
               },
               "variadic": false,
               "docs": {
-                "summary": "- a {@link mocks.functions.FunctionExecutionExample }."
+                "summary": "- a {@link interactions.functions.FunctionExecutionExample }."
               }
             }
           ],
@@ -2516,14 +2516,14 @@
                     "displayName": "ThrowingFunctionExecutionExample",
                     "fqn": "@contract-case/case-definition-dsl.interactions.functions.ThrowingFunctionExecutionExample",
                     "packageName": "@contract-case/case-definition-dsl",
-                    "packageVersion": "0.31.1",
+                    "packageVersion": "0.31.2",
                     "submodule": "interactions"
                   }
                 ]
               },
               "variadic": false,
               "docs": {
-                "summary": "- a {@link mocks.functions.FunctionExecutionExample }."
+                "summary": "- a {@link interactions.functions.FunctionExecutionExample }."
               }
             }
           ],
@@ -2613,14 +2613,14 @@
                     "displayName": "HttpExample",
                     "fqn": "@contract-case/case-definition-dsl.interactions.http.HttpExample",
                     "packageName": "@contract-case/case-definition-dsl",
-                    "packageVersion": "0.31.1",
+                    "packageVersion": "0.31.2",
                     "submodule": "interactions"
                   }
                 ]
               },
               "variadic": false,
               "docs": {
-                "summary": "- an {@link mocks.http.HttpExample }."
+                "summary": "- an {@link interactions.http.HttpExample }."
               }
             }
           ],
@@ -2701,7 +2701,7 @@
                     "displayName": "HttpExample",
                     "fqn": "@contract-case/case-definition-dsl.interactions.http.HttpExample",
                     "packageName": "@contract-case/case-definition-dsl",
-                    "packageVersion": "0.31.1",
+                    "packageVersion": "0.31.2",
                     "submodule": "interactions"
                   }
                 ]
@@ -2937,7 +2937,7 @@
                   "displayName": "ContractCaseCoreBehaviour",
                   "fqn": "@contract-case/case-definition-dsl.interactions.base.ContractCaseCoreBehaviour",
                   "packageName": "@contract-case/case-definition-dsl",
-                  "packageVersion": "0.31.1",
+                  "packageVersion": "0.31.2",
                   "submodule": "interactions"
                 }
               ]
@@ -2959,7 +2959,7 @@
                   "displayName": "ContractCaseCoreBehaviour",
                   "fqn": "@contract-case/case-definition-dsl.interactions.base.ContractCaseCoreBehaviour",
                   "packageName": "@contract-case/case-definition-dsl",
-                  "packageVersion": "0.31.1",
+                  "packageVersion": "0.31.2",
                   "submodule": "interactions"
                 }
               ]

--- a/packages/case-definition-dsl/docs/case-definition-dsl.interactions.functions.willcallfunction._constructor_.md
+++ b/packages/case-definition-dsl/docs/case-definition-dsl.interactions.functions.willcallfunction._constructor_.md
@@ -37,7 +37,7 @@ example
 
 </td><td>
 
-a
+a [interactions.functions.FunctionExecutionExample](./case-definition-dsl.interactions.functions.functionexecutionexample.md)
 
 </td></tr>
 </tbody></table>

--- a/packages/case-definition-dsl/docs/case-definition-dsl.interactions.functions.willcallthrowingfunction._constructor_.md
+++ b/packages/case-definition-dsl/docs/case-definition-dsl.interactions.functions.willcallthrowingfunction._constructor_.md
@@ -37,7 +37,7 @@ example
 
 </td><td>
 
-a
+a [interactions.functions.FunctionExecutionExample](./case-definition-dsl.interactions.functions.functionexecutionexample.md)
 
 </td></tr>
 </tbody></table>

--- a/packages/case-definition-dsl/docs/case-definition-dsl.interactions.functions.willreceivefunctioncall._constructor_.md
+++ b/packages/case-definition-dsl/docs/case-definition-dsl.interactions.functions.willreceivefunctioncall._constructor_.md
@@ -37,7 +37,7 @@ example
 
 </td><td>
 
-a
+a [interactions.functions.FunctionExecutionExample](./case-definition-dsl.interactions.functions.functionexecutionexample.md)
 
 </td></tr>
 </tbody></table>

--- a/packages/case-definition-dsl/docs/case-definition-dsl.interactions.functions.willreceivefunctioncallandthrow._constructor_.md
+++ b/packages/case-definition-dsl/docs/case-definition-dsl.interactions.functions.willreceivefunctioncallandthrow._constructor_.md
@@ -37,7 +37,7 @@ example
 
 </td><td>
 
-a
+a [interactions.functions.FunctionExecutionExample](./case-definition-dsl.interactions.functions.functionexecutionexample.md)
 
 </td></tr>
 </tbody></table>

--- a/packages/case-definition-dsl/docs/case-definition-dsl.interactions.http.willreceivehttprequest._constructor_.md
+++ b/packages/case-definition-dsl/docs/case-definition-dsl.interactions.http.willreceivehttprequest._constructor_.md
@@ -37,7 +37,7 @@ httpExample
 
 </td><td>
 
-an
+an [interactions.http.HttpExample](./case-definition-dsl.interactions.http.httpexample.md)
 
 </td></tr>
 </tbody></table>

--- a/packages/case-definition-dsl/docs/case-definition-dsl.matchers.base.anymatcher._constructor_.md
+++ b/packages/case-definition-dsl/docs/case-definition-dsl.matchers.base.anymatcher._constructor_.md
@@ -4,7 +4,7 @@
 
 ## matchers.base.AnyMatcher.(constructor)
 
-The base class for all Test Equivalence Matchers. Extend this if you don't have an example in your Matcher. Otherwise, use Matcher strings beginning with `_case:` are reserved for the default ContractCase matchers.
+The base class for all Test Equivalence Matchers. Extend this if you don't have an example in your Matcher. Otherwise, use [matchers.base.AnyMatcherWithExample](./case-definition-dsl.matchers.base.anymatcherwithexample.md) Matcher strings beginning with `_case:` are reserved for the default ContractCase matchers.
 
 Only use a types prefixed with `_case:` if you wish to create a special case for a matching behaviour that is already provided by a core ContractCase matcher.
 

--- a/packages/case-definition-dsl/docs/case-definition-dsl.matchers.base.anymatcher.md
+++ b/packages/case-definition-dsl/docs/case-definition-dsl.matchers.base.anymatcher.md
@@ -35,7 +35,7 @@ Description
 
 </td><td>
 
-The base class for all Test Equivalence Matchers. Extend this if you don't have an example in your Matcher. Otherwise, use Matcher strings beginning with `_case:` are reserved for the default ContractCase matchers.
+The base class for all Test Equivalence Matchers. Extend this if you don't have an example in your Matcher. Otherwise, use [matchers.base.AnyMatcherWithExample](./case-definition-dsl.matchers.base.anymatcherwithexample.md) Matcher strings beginning with `_case:` are reserved for the default ContractCase matchers.
 
 Only use a types prefixed with `_case:` if you wish to create a special case for a matching behaviour that is already provided by a core ContractCase matcher.
 

--- a/packages/case-definition-dsl/src/interactions/functions/MockFunctionCall.ts
+++ b/packages/case-definition-dsl/src/interactions/functions/MockFunctionCall.ts
@@ -40,7 +40,7 @@ export class WillReceiveFunctionCall extends AnyInteractionDescriptor {
   /**
    * Defines an example that expects a function to be called with specific arguments
    *
-   * @param example - a {@link mocks.functions.FunctionExecutionExample}
+   * @param example - a {@link interactions.functions.FunctionExecutionExample}
    */
   constructor(example: FunctionExecutionExample) {
     super(MOCK_FUNCTION_CALLER, {

--- a/packages/case-definition-dsl/src/interactions/functions/MockFunctionExecution.ts
+++ b/packages/case-definition-dsl/src/interactions/functions/MockFunctionExecution.ts
@@ -41,7 +41,7 @@ export class WillCallFunction extends AnyInteractionDescriptor {
    * Defines an interaction that executes a registered function with specific arguments,
    * expecting that interaction to return successfully
    *
-   * @param example - a {@link mocks.functions.FunctionExecutionExample}
+   * @param example - a {@link interactions.functions.FunctionExecutionExample}
    */
   constructor(example: FunctionExecutionExample) {
     super(MOCK_FUNCTION_EXECUTION, {

--- a/packages/case-definition-dsl/src/interactions/functions/MockFunctionFailingCall.ts
+++ b/packages/case-definition-dsl/src/interactions/functions/MockFunctionFailingCall.ts
@@ -40,7 +40,7 @@ export class WillReceiveFunctionCallAndThrow extends AnyInteractionDescriptor {
   /**
    * Defines an example that expects a function to be called with specific arguments
    *
-   * @param example - a {@link mocks.functions.FunctionExecutionExample}
+   * @param example - a {@link interactions.functions.FunctionExecutionExample}
    */
   constructor(example: ThrowingFunctionExecutionExample) {
     super(MOCK_FUNCTION_CALLER, {

--- a/packages/case-definition-dsl/src/interactions/functions/MockFunctionFailure.ts
+++ b/packages/case-definition-dsl/src/interactions/functions/MockFunctionFailure.ts
@@ -41,7 +41,7 @@ export class WillCallThrowingFunction extends AnyInteractionDescriptor {
   /**
    * Defines an example that executes a registered function with specific arguments
    *
-   * @param example - a {@link mocks.functions.FunctionExecutionExample}
+   * @param example - a {@link interactions.functions.FunctionExecutionExample}
    */
   constructor(example: ThrowingFunctionExecutionExample) {
     super(MOCK_FUNCTION_EXECUTION, {

--- a/packages/case-definition-dsl/src/interactions/http/WillReceiveHttpRequest.ts
+++ b/packages/case-definition-dsl/src/interactions/http/WillReceiveHttpRequest.ts
@@ -36,7 +36,7 @@ export class WillReceiveHttpRequest extends AnyInteractionDescriptor {
   /**
    * Defines an example that expects to receive an HTTP request. Use this to define a contract at an HTTP client.
    *
-   * @param httpExample - an {@link mocks.http.HttpExample}
+   * @param httpExample - an {@link interactions.http.HttpExample}
    */
   constructor(httpExample: HttpExample) {
     super(MOCK_HTTP_CLIENT, {

--- a/packages/case-definition-dsl/src/matchers/base/AnyMatcher.ts
+++ b/packages/case-definition-dsl/src/matchers/base/AnyMatcher.ts
@@ -11,7 +11,7 @@ export abstract class AnyMatcher {
 
   /**
    * The base class for all Test Equivalence Matchers. Extend this if you don't
-   * have an example in your Matcher. Otherwise, use {@link matchers.internals.AnyMatcherWithExample}
+   * have an example in your Matcher. Otherwise, use {@link matchers.base.AnyMatcherWithExample}
    * Matcher strings beginning with `_case:` are reserved for the default ContractCase
    * matchers.
    *

--- a/packages/case-plugin-base/api-extractor/case-plugin-base.api.json
+++ b/packages/case-plugin-base/api-extractor/case-plugin-base.api.json
@@ -976,7 +976,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@contract-case/case-plugin-base!CheckMatchFn:type",
-          "docComment": "/**\n * Checks a matcher against some actual data and returns a Promise containing a MatchResult.\n *\n * For checks beyond this matcher, use {@link MatchContext#descendAndCheck} to descend into any children.\n *\n * @remarks\n *\n * This function must have no side effects. It may be called repeatedly on the same data by ContractCase during a run.\n *\n * It must not modify the matcher descriptor during a run, but you may generate alternate matcher descriptors when you call the descend methods on the context.\n *\n * Note that calling check and strip together must always return no errors:\n * ```\n * yourMatcher.check(\n *   descriptor,\n *   context,\n *   yourMatcher.strip(descriptor)\n * ) // must be a `MatchResult` with no errors\n * ```\n *\n * @param matcher - the matcher descriptor\n *\n * @param matchContext - the {@link MatchContext} for this run\n *\n * @param actual - the actual data to check against\n *\n * @typeParam T - a matcher descriptor\n *\n * @returns either a Promise containing a {@link MatchResult} or a raw {@link MatchResult}. The Promise return type is preferred.\n *\n * @public\n */\n",
+          "docComment": "/**\n * Checks a matcher against some actual data and returns a Promise containing a MatchResult.\n *\n * For checks beyond this matcher, use `descendAndCheck` on the {@link MatchContext} to descend into any children.\n *\n * @remarks\n *\n * This function must have no side effects. It may be called repeatedly on the same data by ContractCase during a run.\n *\n * It must not modify the matcher descriptor during a run, but you may generate alternate matcher descriptors when you call the descend methods on the context.\n *\n * Note that calling check and strip together must always return no errors:\n * ```\n * yourMatcher.check(\n *   descriptor,\n *   context,\n *   yourMatcher.strip(descriptor)\n * ) // must be a `MatchResult` with no errors\n * ```\n *\n * @param matcher - the matcher descriptor\n *\n * @param matchContext - the {@link MatchContext} for this run\n *\n * @param actual - the actual data to check against\n *\n * @typeParam T - a matcher descriptor\n *\n * @returns either a Promise containing a {@link MatchResult} or a raw {@link MatchResult}. The Promise return type is preferred.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -1899,7 +1899,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@contract-case/case-plugin-base!ContractCaseDslPlugin:type",
-          "docComment": "/**\n * Represents just the part of a plugin that can be used to generate DSL classes. This is exported seprately, as processors that want to use the DSL declaration might not know (or care about) the type parameters for the overall plugin.\n */\n",
+          "docComment": "/**\n * Represents just the part of a plugin that can be used to generate DSL classes. This is exported seprately, as processors that want to use the DSL declaration might not know (or care about) the type parameters for the overall plugin.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2430,7 +2430,7 @@
         {
           "kind": "Function",
           "canonicalReference": "@contract-case/case-plugin-base!coreLookupMatcher:function(1)",
-          "docComment": "/**\n * Creates a matcher descriptor for a lookupable matcher.\n *\n * @remarks\n *\n * Useful if you want to automatically name lookupable matcher descriptors in your plugin.\n *\n * Note that lookup matchers must have identical contents when rendered.\n *\n * @param uniqueName - the name for this lookupable matcher\n *\n * @param child - the contents of this lookupable matcher\n *\n * @returns a {@link @contract-case/case-plugin-dsl-types#LookupableMatcher}\n *\n * @public\n */\n",
+          "docComment": "/**\n * Creates a matcher descriptor for a lookupable matcher.\n *\n * @remarks\n *\n * Useful if you want to automatically name lookupable matcher descriptors in your plugin.\n *\n * Note that lookup matchers must have identical contents when rendered.\n *\n * @param uniqueName - the name for this lookupable matcher\n *\n * @param child - the contents of this lookupable matcher\n *\n * @returns a `LookupableMatcher` (from `@contract-case/case-plugin-dsl-types`)\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -3023,7 +3023,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@contract-case/case-plugin-base!DslObjectDeclaration:type",
-          "docComment": "/**\n * Defines an object.\n */\n",
+          "docComment": "/**\n * Defines an object.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -3727,7 +3727,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@contract-case/case-plugin-base!InteractionDslDeclaration:type",
-          "docComment": "",
+          "docComment": "/**\n * Defines the DSL for an interaction (also known as a mock or an example).\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -3978,7 +3978,7 @@
         {
           "kind": "Function",
           "canonicalReference": "@contract-case/case-plugin-base!isPassToMatcher:function(1)",
-          "docComment": "",
+          "docComment": "/**\n * Type guard function that determines whether a ParameterType is a PassToMatcher or a plain string type.\n *\n * @param parameterType - The parameter type to check\n *\n * @returns true if the parameter is a PassToMatcher, false otherwise\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -4030,7 +4030,7 @@
         {
           "kind": "Function",
           "canonicalReference": "@contract-case/case-plugin-base!isTypeContainer:function(1)",
-          "docComment": "/**\n * Type guard function that determines whether a ParameterType is a TypeContainer or a plain string type.\n *\n * @param parameterType - The parameter type to check\n *\n * @returns true if the parameter is a TypeContainer, false if it's a string\n */\n",
+          "docComment": "/**\n * Type guard function that determines whether a ParameterType is a TypeContainer or a plain string type.\n *\n * @param parameterType - The parameter type to check\n *\n * @returns true if the parameter is a TypeContainer, false if it's a string\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -4750,7 +4750,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@contract-case/case-plugin-base!MatcherDslDeclaration:type",
-          "docComment": "/**\n * Defines the DSL for a matcher.\n *\n * Note that more than one Matcher DSL can point to the same matcher implementation - that is, you might have multiple DSL objects with the same type.\n */\n",
+          "docComment": "/**\n * Defines the DSL for a matcher.\n *\n * Note that more than one Matcher DSL can point to the same matcher implementation - that is, you might have multiple DSL objects with the same type.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -5017,7 +5017,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@contract-case/case-plugin-base!MatcherReference:type",
-          "docComment": "/**\n * A MatcherReference uniquely identifies a matcher and allows generated code to import and use it\n */\n",
+          "docComment": "/**\n * A MatcherReference uniquely identifies a matcher and allows generated code to import and use it\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -5609,7 +5609,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@contract-case/case-plugin-base!MockExecutor:type",
-          "docComment": "/**\n * Describes a mock executor for a plugin\n */\n",
+          "docComment": "/**\n * Describes a mock executor for a plugin\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6033,7 +6033,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@contract-case/case-plugin-base!ParameterDeclaration:type",
-          "docComment": "/**\n * Declares a parameter for a matcher\n */\n",
+          "docComment": "/**\n * Declares a parameter for a matcher\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6068,7 +6068,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@contract-case/case-plugin-base!ParameterType:type",
-          "docComment": "/**\n * ParameterType tells us what type a parameter is.\n *\n * Possible string values: - `'AnyCaseMatcherOrData'`: Matches arbitrary data or a ContractCase matcher. This is ContractCase's most generic unknown type. - `'AnyData'`: Matches any data value only, ie, can't be a matcher. This is like saying \"any json object\". - `'integer'`: Matches integer numbers - `'string'`: Matches string values - `'boolean'`: Matches boolean values - `'number'`: Matches any numeric value. Because the contract serialises to json, this practically means double precision floating point; although the json spec doesn't actually specify, most implementations are restricted to double precision floating point. - `'null'`: Matches `null` values. Friends don't let friends match null values. - `'InternalContractCaseCoreSetup'`: This is the complex json that tells contractcase how to setup itself. This is here for completeness, but you probably don't want to declare it in your own types. If you are implementing a DSL generator for a new language, treat this as whatever a json object would naturally be (eg, a map or dictionary).\n *\n * See {@link TypeContainer} for complex types.\n */\n",
+          "docComment": "/**\n * ParameterType tells us what type a parameter is.\n *\n * Possible string values: - `'AnyCaseMatcherOrData'`: Matches arbitrary data or a ContractCase matcher. This is ContractCase's most generic unknown type. - `'AnyData'`: Matches any data value only, ie, can't be a matcher. This is like saying \"any json object\". - `'integer'`: Matches integer numbers - `'string'`: Matches string values - `'boolean'`: Matches boolean values - `'number'`: Matches any numeric value. Because the contract serialises to json, this practically means double precision floating point; although the json spec doesn't actually specify, most implementations are restricted to double precision floating point. - `'null'`: Matches `null` values. Friends don't let friends match null values. - `'InternalContractCaseCoreSetup'`: This is the complex json that tells contractcase how to setup itself. This is here for completeness, but you probably don't want to declare it in your own types. If you are implementing a DSL generator for a new language, treat this as whatever a json object would naturally be (eg, a map or dictionary).\n *\n * See {@link TypeContainer} for complex types.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6108,7 +6108,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@contract-case/case-plugin-base!PassToMatcher:type",
-          "docComment": "/**\n * Indicates a parameter type which assigns the given parameter(s) to a matcher.\n *\n * This is useful for making composite matchers.\n *\n * See the definition of the core function plugin for an example.\n */\n",
+          "docComment": "/**\n * Indicates a parameter type which assigns the given parameter(s) to a matcher.\n *\n * This is useful for making composite matchers.\n *\n * See the definition of the core function plugin for an example.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6178,7 +6178,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@contract-case/case-plugin-base!PluginDslDeclaration:type",
-          "docComment": "",
+          "docComment": "/**\n * Describes all the DSL classes declared by a plugin, so that they can be generated in each supported language.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6231,7 +6231,7 @@
         {
           "kind": "Function",
           "canonicalReference": "@contract-case/case-plugin-base!providePluginContext:function(1)",
-          "docComment": "/**\n * Overwrites the value of '_case:currentRun:context:pluginProvided' with the provided context. Generally you want to call this once per interaction executor entry function.\n *\n * @param parentContext - Context to extend with provided context\n *\n * @param providedContext - Context that your plugin is providing\n *\n * @returns A copy of the context, with the given plugin-provided context set.\n */\n",
+          "docComment": "/**\n * Overwrites the value of '_case:currentRun:context:pluginProvided' with the provided context. Generally you want to call this once per interaction executor entry function.\n *\n * @param parentContext - Context to extend with provided context\n *\n * @param providedContext - Context that your plugin is providing\n *\n * @returns A copy of the context, with the given plugin-provided context set.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6605,7 +6605,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@contract-case/case-plugin-base!StateObjectDeclaration:type",
-          "docComment": "",
+          "docComment": "/**\n * Defines the DSL for a state object.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -7251,7 +7251,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@contract-case/case-plugin-base!TypeContainer:type",
-          "docComment": "/**\n * Indicates a container type.\n *\n * Currently only supports arrays, but in the future may allow specific matchers.\n *\n * Implementations should switch on `kind` and fail if they get a kind that they don't recognise.\n *\n * If you have a use-case that needs more complex container types, please raise an issue.\n */\n",
+          "docComment": "/**\n * Indicates a container type.\n *\n * Currently only supports arrays, but in the future may allow specific matchers.\n *\n * Implementations should switch on `kind` and fail if they get a kind that they don't recognise.\n *\n * If you have a use-case that needs more complex container types, please raise an issue.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -7286,7 +7286,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@contract-case/case-plugin-base!ValidateMatcherFn:type",
-          "docComment": "/**\n * Validates the parameters of this matcher. ContractCase does two kinds of validation:\n *\n * - It calls `validate(matcher)`, to confirm that the parameters are appropriately set (this function) - It calls `check(matcher,context, strip(matcher))`, to confirm that the user's example matches itself.\n *\n * Because of the second check, you generally don't need to validate structure in this function. Use cases for this validation function are where only a subset of values are valid. For example, the HTTP Status Code validation function will accept the string `\"200\"`, but not the string `\"The type system accepts this incorrect value\"`.\n *\n * Like the other matcher functions, use {@link MatchContext#descendAndValidate} to descend into any children.\n *\n * If any of the Matcher's properties fail validation, throw a CaseConfigurationError.\n *\n * @remarks\n *\n * This function must have no side effects, it may be called repeatedly on the same data by ContractCase during a run.\n * ```\n * yourMatcher.check(\n *   descriptor,\n *   context,\n *   yourMatcher.strip(descriptor)\n * ) // must be a `MatchResult` with no errors\n * ```\n *\n * @param matcher - the matcher descriptor\n *\n * @param matchContext - the {@link MatchContext} for this run\n *\n * @typeParam T - a matcher descriptor\n *\n * @returns a void `Promise`, rejected with `CaseConfigurationError` if the validation failed.\n *\n * @public\n */\n",
+          "docComment": "/**\n * Validates the parameters of this matcher. ContractCase does two kinds of validation:\n *\n * - It calls `validate(matcher)`, to confirm that the parameters are appropriately set (this function) - It calls `check(matcher,context, strip(matcher))`, to confirm that the user's example matches itself.\n *\n * Because of the second check, you generally don't need to validate structure in this function. Use cases for this validation function are where only a subset of values are valid. For example, the HTTP Status Code validation function will accept the string `\"200\"`, but not the string `\"The type system accepts this incorrect value\"`.\n *\n * Like the other matcher functions, use `descendAndValidate` on the {@link MatchContext} to descend into any children.\n *\n * If any of the Matcher's properties fail validation, throw a CaseConfigurationError.\n *\n * @remarks\n *\n * This function must have no side effects, it may be called repeatedly on the same data by ContractCase during a run.\n * ```\n * yourMatcher.check(\n *   descriptor,\n *   context,\n *   yourMatcher.strip(descriptor)\n * ) // must be a `MatchResult` with no errors\n * ```\n *\n * @param matcher - the matcher descriptor\n *\n * @param matchContext - the {@link MatchContext} for this run\n *\n * @typeParam T - a matcher descriptor\n *\n * @returns a void `Promise`, rejected with `CaseConfigurationError` if the validation failed.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",

--- a/packages/case-plugin-base/api-extractor/case-plugin-base.api.md
+++ b/packages/case-plugin-base/api-extractor/case-plugin-base.api.md
@@ -317,7 +317,7 @@ export interface HttpTestContext {
     baseUrl: string;
 }
 
-// @public (undocumented)
+// @public
 export type InteractionDslDeclaration = DslObjectDeclaration & {
     readonly setup: InternalContractCaseCoreSetup;
 };
@@ -339,7 +339,7 @@ export interface IsMockDescriptorForType<T extends string> {
     '_case:run:context:setup': InternalContractCaseCoreSetup;
 }
 
-// @public (undocumented)
+// @public
 export const isPassToMatcher: (parameterType: ParameterType) => parameterType is PassToMatcher;
 
 // @public
@@ -523,7 +523,7 @@ export type PluginDescription = {
     version: string;
 };
 
-// @public (undocumented)
+// @public
 export type PluginDslDeclaration = {
     readonly namespace: string;
     readonly category: string;
@@ -619,7 +619,7 @@ export const SERIALISABLE_TO_JSON: "json";
 // @internal
 export const shouldLog: (context: LogLevelContext, logLevel: LogLevel) => boolean;
 
-// @public (undocumented)
+// @public
 export type StateObjectDeclaration = DslObjectDeclaration;
 
 // @public

--- a/packages/case-plugin-base/docs/case-plugin-base.checkmatchfn.md
+++ b/packages/case-plugin-base/docs/case-plugin-base.checkmatchfn.md
@@ -6,7 +6,7 @@
 
 Checks a matcher against some actual data and returns a Promise containing a MatchResult.
 
-For checks beyond this matcher, use  to descend into any children.
+For checks beyond this matcher, use `descendAndCheck` on the [MatchContext](./case-plugin-base.matchcontext.md) to descend into any children.
 
 **Signature:**
 

--- a/packages/case-plugin-base/docs/case-plugin-base.corelookupmatcher.md
+++ b/packages/case-plugin-base/docs/case-plugin-base.corelookupmatcher.md
@@ -68,7 +68,7 @@ the contents of this lookupable matcher
 
 LookupableMatcher
 
-a 
+a `LookupableMatcher` (from `@contract-case/case-plugin-dsl-types`<!-- -->)
 
 ## Remarks
 

--- a/packages/case-plugin-base/docs/case-plugin-base.interactiondsldeclaration.md
+++ b/packages/case-plugin-base/docs/case-plugin-base.interactiondsldeclaration.md
@@ -4,6 +4,8 @@
 
 ## InteractionDslDeclaration type
 
+Defines the DSL for an interaction (also known as a mock or an example).
+
 **Signature:**
 
 ```typescript

--- a/packages/case-plugin-base/docs/case-plugin-base.ispasstomatcher.md
+++ b/packages/case-plugin-base/docs/case-plugin-base.ispasstomatcher.md
@@ -4,6 +4,8 @@
 
 ## isPassToMatcher() function
 
+Type guard function that determines whether a ParameterType is a PassToMatcher or a plain string type.
+
 **Signature:**
 
 ```typescript
@@ -40,6 +42,8 @@ parameterType
 
 </td><td>
 
+The parameter type to check
+
 
 </td></tr>
 </tbody></table>
@@ -47,4 +51,6 @@ parameterType
 **Returns:**
 
 parameterType is [PassToMatcher](./case-plugin-base.passtomatcher.md)
+
+true if the parameter is a PassToMatcher, false otherwise
 

--- a/packages/case-plugin-base/docs/case-plugin-base.md
+++ b/packages/case-plugin-base/docs/case-plugin-base.md
@@ -327,6 +327,8 @@ Type guard to determine if an object is a ContractCase matcher descriptor or not
 
 </td><td>
 
+Type guard function that determines whether a ParameterType is a PassToMatcher or a plain string type.
+
 
 </td></tr>
 <tr><td>
@@ -834,7 +836,7 @@ Helper type to extract a case matcher descriptor out of a list of descriptors
 
 Checks a matcher against some actual data and returns a Promise containing a MatchResult.
 
-For checks beyond this matcher, use  to descend into any children.
+For checks beyond this matcher, use `descendAndCheck` on the [MatchContext](./case-plugin-base.matchcontext.md) to descend into any children.
 
 
 </td></tr>
@@ -947,6 +949,8 @@ A matcher descriptor that has an example
 
 
 </td><td>
+
+Defines the DSL for an interaction (also known as a mock or an example).
 
 
 </td></tr>
@@ -1140,6 +1144,8 @@ Describes the plugin name and version
 
 </td><td>
 
+Describes all the DSL classes declared by a plugin, so that they can be generated in each supported language.
+
 
 </td></tr>
 <tr><td>
@@ -1148,6 +1154,8 @@ Describes the plugin name and version
 
 
 </td><td>
+
+Defines the DSL for a state object.
 
 
 </td></tr>
@@ -1192,7 +1200,7 @@ Validates the parameters of this matcher. ContractCase does two kinds of validat
 
 Because of the second check, you generally don't need to validate structure in this function. Use cases for this validation function are where only a subset of values are valid. For example, the HTTP Status Code validation function will accept the string `"200"`<!-- -->, but not the string `"The type system accepts this incorrect value"`<!-- -->.
 
-Like the other matcher functions, use  to descend into any children.
+Like the other matcher functions, use `descendAndValidate` on the [MatchContext](./case-plugin-base.matchcontext.md) to descend into any children.
 
 If any of the Matcher's properties fail validation, throw a CaseConfigurationError.
 

--- a/packages/case-plugin-base/docs/case-plugin-base.plugindsldeclaration.md
+++ b/packages/case-plugin-base/docs/case-plugin-base.plugindsldeclaration.md
@@ -4,6 +4,8 @@
 
 ## PluginDslDeclaration type
 
+Describes all the DSL classes declared by a plugin, so that they can be generated in each supported language.
+
 **Signature:**
 
 ```typescript

--- a/packages/case-plugin-base/docs/case-plugin-base.stateobjectdeclaration.md
+++ b/packages/case-plugin-base/docs/case-plugin-base.stateobjectdeclaration.md
@@ -4,6 +4,8 @@
 
 ## StateObjectDeclaration type
 
+Defines the DSL for a state object.
+
 **Signature:**
 
 ```typescript

--- a/packages/case-plugin-base/docs/case-plugin-base.validatematcherfn.md
+++ b/packages/case-plugin-base/docs/case-plugin-base.validatematcherfn.md
@@ -10,7 +10,7 @@ Validates the parameters of this matcher. ContractCase does two kinds of validat
 
 Because of the second check, you generally don't need to validate structure in this function. Use cases for this validation function are where only a subset of values are valid. For example, the HTTP Status Code validation function will accept the string `"200"`<!-- -->, but not the string `"The type system accepts this incorrect value"`<!-- -->.
 
-Like the other matcher functions, use  to descend into any children.
+Like the other matcher functions, use `descendAndValidate` on the [MatchContext](./case-plugin-base.matchcontext.md) to descend into any children.
 
 If any of the Matcher's properties fail validation, throw a CaseConfigurationError.
 

--- a/packages/case-plugin-base/src/context/pluginConfig.ts
+++ b/packages/case-plugin-base/src/context/pluginConfig.ts
@@ -7,6 +7,7 @@ import { DataContext, MatchContext } from './types';
  * with the provided context. Generally you want to call this once per
  * interaction executor entry function.
  *
+ * @public
  * @param parentContext - Context to extend with provided context
  * @param providedContext - Context that your plugin is providing
  * @returns A copy of the context, with the given plugin-provided context set.

--- a/packages/case-plugin-base/src/dsl/types.ts
+++ b/packages/case-plugin-base/src/dsl/types.ts
@@ -1,5 +1,10 @@
 import { InternalContractCaseCoreSetup } from '@contract-case/case-plugin-dsl-types';
 
+/**
+ * Describes all the DSL classes declared by a plugin, so that
+ * they can be generated in each supported language.
+ * @public
+ */
 export type PluginDslDeclaration = {
   /**
    * The author's namespace for these DSL classes.
@@ -71,6 +76,7 @@ export type PluginDslDeclaration = {
  *    whatever a json object would naturally be (eg, a map or dictionary).
  *
  * See {@link TypeContainer} for complex types.
+ * @public
  */
 export type ParameterType =
   | TypeContainer
@@ -95,6 +101,7 @@ export type ParameterType =
  *
  * If you have a use-case that needs more complex container types, please raise
  * an issue.
+ * @public
  */
 export type TypeContainer = {
   /** What kind of container this is. Future unions of this type will always have this parameter */
@@ -103,7 +110,10 @@ export type TypeContainer = {
   readonly type: ParameterType;
 };
 
-/** A MatcherReference uniquely identifies a matcher and allows generated code to import and use it */
+/**
+ * A MatcherReference uniquely identifies a matcher and allows generated code to import and use it
+ * @public
+ */
 export type MatcherReference = {
   /** The name of the matcher to pass the parameters to */
   readonly name: string;
@@ -119,6 +129,7 @@ export type MatcherReference = {
  * This is useful for making composite matchers.
  *
  * See the definition of the core function plugin for an example.
+ * @public
  */
 export type PassToMatcher = {
   /** What kind of container this is. Future unions of this type will always have this parameter */
@@ -142,6 +153,7 @@ export type PassToMatcher = {
  * Type guard function that determines whether a ParameterType is a TypeContainer
  * or a plain string type.
  *
+ * @public
  * @param parameterType - The parameter type to check
  * @returns true if the parameter is a TypeContainer, false if it's a string
  */
@@ -150,6 +162,13 @@ export const isTypeContainer = (
 ): parameterType is TypeContainer =>
   typeof parameterType === 'object' && parameterType.kind === 'array';
 
+/**
+ * Type guard function that determines whether a ParameterType is a PassToMatcher
+ * or a plain string type.
+ * @public
+ * @param parameterType - The parameter type to check
+ * @returns true if the parameter is a PassToMatcher, false otherwise
+ */
 export const isPassToMatcher = (
   parameterType: ParameterType,
 ): parameterType is PassToMatcher =>
@@ -157,6 +176,7 @@ export const isPassToMatcher = (
 
 /**
  * Declares a parameter for a matcher
+ * @public
  */
 export type ParameterDeclaration = {
   /**
@@ -199,7 +219,10 @@ export type ParameterDeclaration = {
   readonly jsonPropertyName?: string;
 };
 
-/** Defines an object. */
+/**
+ * Defines an object.
+ * @public
+ */
 export type DslObjectDeclaration = {
   /*
    * The name of the DSL matcher, in CamelCase with no spaces.
@@ -238,6 +261,7 @@ export type DslObjectDeclaration = {
  * Note that more than one Matcher DSL can point
  * to the same matcher implementation - that is, you might have
  * multiple DSL objects with the same type.
+ * @public
  */
 export type MatcherDslDeclaration = DslObjectDeclaration & {
   /**
@@ -276,8 +300,16 @@ export type MatcherDslDeclaration = DslObjectDeclaration & {
   readonly currentRunModifiers?: Record<string, string>;
 };
 
+/**
+ * Defines the DSL for a state object.
+ * @public
+ */
 export type StateObjectDeclaration = DslObjectDeclaration;
 
+/**
+ * Defines the DSL for an interaction (also known as a mock or an example).
+ * @public
+ */
 export type InteractionDslDeclaration = DslObjectDeclaration & {
   /**
    * Controls the behaviour of the mocked interaction for definition and verification

--- a/packages/case-plugin-base/src/matchers/executors.types.ts
+++ b/packages/case-plugin-base/src/matchers/executors.types.ts
@@ -7,8 +7,8 @@ import { DescribeSegment } from './describe';
 /**
  * Checks a matcher against some actual data and returns a Promise containing a MatchResult.
  *
- * For checks beyond this matcher, use {@link MatchContext#descendAndCheck} to
- * descend into any children.
+ * For checks beyond this matcher, use `descendAndCheck` on the
+ * {@link MatchContext} to descend into any children.
  *
  * @remarks
  *
@@ -55,8 +55,8 @@ export type CheckMatchFn<T> = (
  * the HTTP Status Code validation function will accept the string `"200"`, but not the string
  * `"The type system accepts this incorrect value"`.
  *
- * Like the other matcher functions, use {@link MatchContext#descendAndValidate} to
- * descend into any children.
+ * Like the other matcher functions, use `descendAndValidate` on the
+ * {@link MatchContext} to descend into any children.
  *
  * If any of the Matcher's properties fail validation, throw a CaseConfigurationError.
  *

--- a/packages/case-plugin-base/src/matchers/lookup.ts
+++ b/packages/case-plugin-base/src/matchers/lookup.ts
@@ -15,7 +15,7 @@ import {
  *
  * @param uniqueName - the name for this lookupable matcher
  * @param child - the contents of this lookupable matcher
- * @returns a {@link @contract-case/case-plugin-dsl-types#LookupableMatcher}
+ * @returns a `LookupableMatcher` (from `@contract-case/case-plugin-dsl-types`)
  */
 export const coreLookupMatcher = (
   uniqueName: string,

--- a/packages/case-plugin-base/src/mocks/executors.types.ts
+++ b/packages/case-plugin-base/src/mocks/executors.types.ts
@@ -82,6 +82,7 @@ export interface IsMockDescriptorForType<T extends string> {
 
 /**
  * Describes a mock executor for a plugin
+ * @public
  */
 export type MockExecutor<
   MockType extends string,

--- a/packages/case-plugin-base/src/types.ts
+++ b/packages/case-plugin-base/src/types.ts
@@ -63,6 +63,7 @@ export type PluginDescription = {
  * Represents just the part of a plugin that can be used to generate DSL classes.
  * This is exported seprately, as processors that want to use the DSL declaration
  * might not know (or care about) the type parameters for the overall plugin.
+ * @public
  */
 export type ContractCaseDslPlugin = {
   description: PluginDescription;

--- a/packages/case-plugin-base/temp/case-plugin-base.api.md
+++ b/packages/case-plugin-base/temp/case-plugin-base.api.md
@@ -317,7 +317,7 @@ export interface HttpTestContext {
     baseUrl: string;
 }
 
-// @public (undocumented)
+// @public
 export type InteractionDslDeclaration = DslObjectDeclaration & {
     readonly setup: InternalContractCaseCoreSetup;
 };
@@ -339,7 +339,7 @@ export interface IsMockDescriptorForType<T extends string> {
     '_case:run:context:setup': InternalContractCaseCoreSetup;
 }
 
-// @public (undocumented)
+// @public
 export const isPassToMatcher: (parameterType: ParameterType) => parameterType is PassToMatcher;
 
 // @public
@@ -523,7 +523,7 @@ export type PluginDescription = {
     version: string;
 };
 
-// @public (undocumented)
+// @public
 export type PluginDslDeclaration = {
     readonly namespace: string;
     readonly category: string;
@@ -619,7 +619,7 @@ export const SERIALISABLE_TO_JSON: "json";
 // @internal
 export const shouldLog: (context: LogLevelContext, logLevel: LogLevel) => boolean;
 
-// @public (undocumented)
+// @public
 export type StateObjectDeclaration = DslObjectDeclaration;
 
 // @public

--- a/packages/documentation/docs/examples/_install_java.mdx
+++ b/packages/documentation/docs/examples/_install_java.mdx
@@ -1,7 +1,7 @@
 ```gradle
 // gradle short
 dependencies {
-    testImplementation 'io.contract-testing.contractcase:contract-case:0.31.1'
+    testImplementation 'io.contract-testing.contractcase:contract-case:0.31.2'
 }
 ```
 
@@ -10,7 +10,7 @@ dependencies {
 <dependency>
     <groupId>io.contract-testing.contractcase</groupId>
     <artifactId>contract-case</artifactId>
-    <version>0.31.1</version>
+    <version>0.31.2</version>
     <scope>test</scope>
 </dependency>
 ```


### PR DESCRIPTION
## Summary

This PR fixes broken documentation links and adds missing JSDoc comments to improve API documentation generation and clarity across the codebase.

## Key Changes

- **Fixed namespace references in documentation**: Updated incorrect `mocks.*` namespace references to `interactions.*` in JSDoc comments for function interaction classes (WillCallFunction, WillCallThrowingFunction, WillReceiveFunctionCall, WillReceiveHttpRequest)

- **Fixed class reference links**: Corrected JSDoc link from `matchers.internals.AnyMatcherWithExample` to `matchers.base.AnyMatcherWithExample` in the AnyMatcher base class

- **Added missing JSDoc documentation**: Added `@public` markers and descriptive comments to previously undocumented or partially documented types and functions:
  - `PluginDslDeclaration` - describes DSL class declarations
  - `ParameterType` - parameter type definitions
  - `TypeContainer` - complex type containers
  - `MatcherReference` - matcher identification
  - `PassToMatcher` - composite matcher support
  - `isPassToMatcher()` - type guard function
  - `isTypeContainer()` - type guard function
  - `ParameterDeclaration` - matcher parameter declarations
  - `DslObjectDeclaration` - object definitions
  - `MatcherDslDeclaration` - matcher DSL definitions
  - `StateObjectDeclaration` - state object definitions
  - `InteractionDslDeclaration` - interaction DSL definitions

- **Improved documentation clarity**: Updated JSDoc comments to use inline code formatting and clearer references:
  - Changed `{@link MatchContext#descendAndCheck}` to backtick-formatted `descendAndCheck` on MatchContext
  - Changed `{@link @contract-case/case-plugin-dsl-types#LookupableMatcher}` to clearer inline reference
  - Added missing parameter descriptions in generated documentation

- **Updated API extractor configuration**: Added message suppression for `ae-unresolved-link` warnings in case-definition-dsl to handle namespace re-export resolution limitations

- **Updated version**: Bumped case-definition-dsl package version from 0.31.1 to 0.31.2

## Notable Implementation Details

- The documentation fixes ensure that generated API documentation (markdown and JSON) correctly references types and functions
- JSDoc comments now consistently include `@public` markers for exported types to ensure proper visibility in generated documentation
- The API extractor configuration change acknowledges a known limitation in rushstack's declaration reference resolver while maintaining validation through api-documenter

https://claude.ai/code/session_01JhUff3VLTEX3VSeyaFXTBi